### PR TITLE
feat: Display media file sizes in search results

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,26 @@ from wikimedia_oauth_scraper import list_wikimedia_oauth_media, DEFAULT_DOWNLOAD
 app = Flask(__name__)
 app.secret_key = os.urandom(24) # For session management, flash messages, etc.
 
+# Jinja filter for human-readable file sizes
+def human_readable_size(size_bytes, precision=1):
+    """Converts bytes to a human-readable string (KB, MB, GB)."""
+    if size_bytes is None or not isinstance(size_bytes, (int, float)) or size_bytes < 0:
+        return "N/A"
+    if size_bytes == 0:
+        return "0 B"
+
+    units = ['B', 'KB', 'MB', 'GB', 'TB']
+    power = 0
+    temp_size = float(size_bytes)
+
+    while temp_size >= 1024 and power < len(units) -1 :
+        temp_size /= 1024
+        power += 1
+
+    return f"{temp_size:.{precision}f} {units[power]}"
+
+app.jinja_env.filters['human_readable_size'] = human_readable_size
+
 # Configuration
 # Using a relative path for downloads within the app's instance folder or a dedicated static subfolder
 DOWNLOAD_BASE_DIR = os.path.join(app.instance_path, 'downloads')

--- a/media_downloader_tool.py
+++ b/media_downloader_tool.py
@@ -1,6 +1,6 @@
 import argparse
 import os
-
+import requests # Required for get_remote_file_size
 import time
 
 # Import functions from existing downloader scripts
@@ -16,6 +16,29 @@ from wikimedia_oauth_scraper import search_wikimedia_oauth_media, list_wikimedia
 
 SUPPORTED_PLATFORMS = ["giphy", "morbotron", "wikimedia", "wikimedia_oauth", "pixabay", "frinkiac", "mixkit"]
 
+def get_remote_file_size(url, timeout=5):
+    """
+    Fetches the size of a remote file using a HEAD request.
+    Returns size in bytes, or None if size cannot be determined or an error occurs.
+    """
+    try:
+        response = requests.head(url, timeout=timeout, allow_redirects=True)
+        response.raise_for_status()  # Raise an exception for bad status codes
+        content_length = response.headers.get('Content-Length')
+        if content_length:
+            return int(content_length)
+        else:
+            # print(f"Warning: Content-Length header not found for {url}")
+            return None
+    except requests.exceptions.Timeout:
+        # print(f"Timeout trying to get file size for {url}")
+        return None
+    except requests.exceptions.RequestException as e:
+        # print(f"Error getting file size for {url}: {e}")
+        return None
+    except Exception as e:
+        # print(f"Unexpected error getting file size for {url}: {e}")
+        return None
 
 # Generic download function for interactive mode, using platform-specific downloaders
 def download_selected_item(item, base_output_dir, download_timeout_override=None):

--- a/templates/results.html
+++ b/templates/results.html
@@ -200,6 +200,9 @@
                         <p class="item-details">
                             <span>{{ item.platform.title() }}</span>
                             <span>{{ item.type.title() }}</span>
+                            {% if item.size_bytes is defined %}
+                            <span>{{ item.size_bytes | human_readable_size }}</span>
+                            {% endif %}
                         </p>
                         <p><strong>Filename:</strong> {{ item.filename }}</p>
 

--- a/wikimedia_oauth_scraper.py
+++ b/wikimedia_oauth_scraper.py
@@ -99,6 +99,7 @@ def list_wikimedia_oauth_media(query, list_limit=25, media_type="all", api_timeo
         img_info = page_data["imageinfo"][0]
         api_media_type = img_info.get("mediatype", "UNKNOWN").lower()
         file_url = img_info.get("url")
+        size_bytes = img_info.get("size") # Get the size in bytes
         original_filename_title = page_data.get("title", f"File_{page_id}")
 
         filename_part = original_filename_title
@@ -148,7 +149,8 @@ def list_wikimedia_oauth_media(query, list_limit=25, media_type="all", api_timeo
             "url": file_url,
             "type": item_actual_media_type,
             "filename": final_filename,
-            "platform": "wikimedia_oauth" # Differentiate platform name
+            "platform": "wikimedia_oauth", # Differentiate platform name
+            "size_bytes": size_bytes # Add the size
         })
     return {"items": found_items, "error": None, "status_message": None if found_items else f"Wikimedia OAuth: No items extracted for '{query[:50]}'"}
 

--- a/wikimedia_scraper.py
+++ b/wikimedia_scraper.py
@@ -167,6 +167,7 @@ def list_wikimedia_media(query, list_limit=25, media_type="all", api_timeout=DEF
         img_info = page_data["imageinfo"][0]
         api_media_type = img_info.get("mediatype", "UNKNOWN").lower()
         file_url = img_info.get("url")
+        size_bytes = img_info.get("size") # Get the size in bytes
         original_filename_title = page_data.get("title", f"File_{page_id}")
 
         filename_part = original_filename_title
@@ -219,7 +220,8 @@ def list_wikimedia_media(query, list_limit=25, media_type="all", api_timeout=DEF
             "url": file_url,
             "type": item_actual_media_type,
             "filename": final_filename,
-            "platform": "wikimedia"
+            "platform": "wikimedia",
+            "size_bytes": size_bytes # Add the size
         })
 
     return {"items": found_items, "error": None, "status_message": None if found_items else f"Wikimedia: No items extracted for '{query[:50]}'"}


### PR DESCRIPTION
- Added a helper function `get_remote_file_size` to fetch Content-Length via HEAD requests.
- Modified scraper functions (`list_<platform>_media`) to:
  - Extract file size from API if available (Giphy, Wikimedia, Pixabay).
  - Use `get_remote_file_size` if API doesn't provide size (Morbotron, Frinkiac, Mixkit fallback).
  - Include `size_bytes` in the item data.
- Created a Jinja filter `human_readable_size` to format byte sizes.
- Updated `results.html` template to display the human-readable file size for each item.