### PR TITLE
feat: Add AdSense script and placeholders

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Unified Media Downloader</title>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4051668463556389"
+     crossorigin="anonymous"></script>
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -181,6 +183,16 @@
             <div class="loader"></div>
             <p>Searching... Please wait.</p>
         </div>
+
+        <!-- AdSense Ad Unit Placeholder - Below Search Form -->
+        <div style="margin-top: 25px; margin-bottom: 25px; text-align: center;">
+            <!-- Replace this comment with your AdSense ad unit code for the index page -->
+            <!-- Example: <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-XXXX" data-ad-slot="YYYY" data-ad-format="auto" data-full-width-responsive="true"></ins> -->
+            <!-- <script>(adsbygoogle = window.adsbygoogle || []).push({});</script> -->
+            <p style="color: #888;">[Ad Placeholder: Index Page Banner]</p>
+        </div>
+        <!-- End AdSense Ad Unit Placeholder -->
+
     </div>
 
     <script>

--- a/templates/results.html
+++ b/templates/results.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Search Results for "{{ query }}"</title>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4051668463556389"
+     crossorigin="anonymous"></script>
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -191,6 +193,13 @@
             </div>
         {% endif %}
 
+        <!-- AdSense Ad Unit Placeholder - Above Results Grid -->
+        <div style="margin-bottom: 20px; text-align: center;">
+            <!-- Replace this comment with your AdSense ad unit code -->
+            <!-- <p style="color: #888;">[Ad Placeholder: Results Page - Top Banner]</p> -->
+        </div>
+        <!-- End AdSense Ad Unit Placeholder -->
+
         {% if display_items %}
             <div class="result-grid">
                 {% for item in display_items %} {# Iterate over the consolidated display_items #}
@@ -242,6 +251,13 @@
         {% else %}
             <p class="no-results">No media items found for your query "{{ query }}" with the selected criteria.</p>
         {% endif %}
+
+        <!-- AdSense Ad Unit Placeholder - Below Results Grid -->
+        <div style="margin-top: 20px; margin-bottom: 20px; text-align: center;">
+            <!-- Replace this comment with your AdSense ad unit code -->
+            <!-- <p style="color: #888;">[Ad Placeholder: Results Page - Bottom Banner]</p> -->
+        </div>
+        <!-- End AdSense Ad Unit Placeholder -->
 
         <div style="text-align: center; margin-top: 30px;">
              <a href="{{ url_for('index') }}" class="nav-link">&larr; New Search</a>


### PR DESCRIPTION
- Added the main Google AdSense script to the <head> of `index.html` and `results.html`.
- Inserted HTML comment placeholders for AdSense ad units in relevant locations on both pages:
  - `index.html`: Below the search form.
  - `results.html`: Above and below the results grid.

These changes prepare the templates for AdSense integration. Actual ad unit codes need to be inserted by replacing the placeholders.