### PR TITLE
Refactor: Remove duplicate AdSense scripts from HTML templates

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -186,8 +186,7 @@
 
         <!-- AdSense Ad Unit Placeholder - Below Search Form -->
         <div style="margin-top: 25px; margin-bottom: 25px; text-align: center;">
-           <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4051668463556389"
-     crossorigin="anonymous"></script>
+            <!-- The AdSense script from <head> will manage ads here -->
             <p style="color: #888;">[Ad Placeholder: Index Page Banner]</p>
         </div>
         <!-- End AdSense Ad Unit Placeholder -->

--- a/templates/results.html
+++ b/templates/results.html
@@ -195,8 +195,7 @@
 
         <!-- AdSense Ad Unit Placeholder - Above Results Grid -->
         <div style="margin-bottom: 20px; text-align: center;">
-            <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4051668463556389"
-     crossorigin="anonymous"></script>
+            <!-- The AdSense script from <head> will manage ads here -->
         </div>
         <!-- End AdSense Ad Unit Placeholder -->
 
@@ -254,8 +253,7 @@
 
         <!-- AdSense Ad Unit Placeholder - Below Results Grid -->
         <div style="margin-top: 20px; margin-bottom: 20px; text-align: center;">
-           <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4051668463556389"
-     crossorigin="anonymous"></script>
+           <!-- The AdSense script from <head> will manage ads here -->
         </div>
         <!-- End AdSense Ad Unit Placeholder -->
 


### PR DESCRIPTION
The AdSense script was included multiple times in both index.html and results.html (in the <head> and multiple times in the <body>).

This change removes the duplicate scripts from the <body> of both files to adhere to best practices and ensure the script is loaded only once per page. The script in the <head> will manage ad loading.